### PR TITLE
Update main.lua

### DIFF
--- a/LegacyFuel/client/main.lua
+++ b/LegacyFuel/client/main.lua
@@ -94,8 +94,8 @@ Citizen.CreateThread(function()
 				elseif IsFueling then
 					local position = GetEntityCoords(vehicle)
 
-					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to cancel the fueling of your vehicle.")
-					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "%")
+					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to cancel the fueling of your vehicle. $~r~" .. price .. " ~w~+  tax")
+					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "L")
 					
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -156,7 +156,7 @@ Citizen.CreateThread(function()
 				local jerrycan = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 				
 				if IsFuelingWithJerryCan then
-					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "% - Jerry Can: " .. jerrycan)
+					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "L - Jerry Can: " .. jerrycan)
 
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -221,11 +221,12 @@ Citizen.CreateThread(function()
 			local integer  = math.random(6, 10)
 			local fuelthis = integer / 10
 			local newfuel  = fuel + fuelthis
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 			Citizen.Wait(150)
 
-			if newfuel < 100 then
+			if newfuel < (maxfuel) then
 				SetVehicleFuelLevel(vehicle, newfuel)
 
 				for i = 1, #Vehicles do
@@ -239,7 +240,7 @@ Citizen.CreateThread(function()
 					end
 				end
 			else
-				SetVehicleFuelLevel(vehicle, 100.0)
+				SetVehicleFuelLevel(vehicle, maxfuel)
 				loadAnimDict("reaction@male_stand@small_intro@forward")
 				TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
@@ -271,13 +272,14 @@ Citizen.CreateThread(function()
 			local jerryfuel = fuelthis * 100
 			local jerrycurr = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 			local jerrynew  = jerrycurr - jerryfuel
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			if jerrycurr >= jerryfuel then
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 				Citizen.Wait(150)
 				SetPedAmmo(GetPlayerPed(-1), 883325847, round(jerrynew, 0))
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -291,7 +293,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 

--- a/esx_legacyfuel/client/main.lua
+++ b/esx_legacyfuel/client/main.lua
@@ -315,7 +315,7 @@ Citizen.CreateThread(function()
 				Citizen.Wait(150)
 				SetPedAmmo(GetPlayerPed(-1), 883325847, round(jerrynew, 0))
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do

--- a/esx_legacyfuel/client/main.lua
+++ b/esx_legacyfuel/client/main.lua
@@ -97,7 +97,7 @@ Citizen.CreateThread(function()
 					local position = GetEntityCoords(vehicle)
 
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to cancel the fueling of your vehicle. $~r~" .. price .. " ~w~+  tax")
-					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "%")
+					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "L")
 					
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -162,7 +162,7 @@ Citizen.CreateThread(function()
 				local jerrycan = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 				
 				if IsFuelingWithJerryCan then
-					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "% - Jerry Can: " .. jerrycan)
+					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "L - Jerry Can: " .. jerrycan)
 
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -227,6 +227,7 @@ Citizen.CreateThread(function()
 			local integer  = math.random(6, 10)
 			local fuelthis = integer / 10
 			local newfuel  = fuel + fuelthis
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			price = price + fuelthis * 0.5 * 1.1
 
@@ -234,7 +235,7 @@ Citizen.CreateThread(function()
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 				Citizen.Wait(150)
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -248,7 +249,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
@@ -307,6 +308,7 @@ Citizen.CreateThread(function()
 			local jerryfuel = fuelthis * 100
 			local jerrycurr = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 			local jerrynew  = jerrycurr - jerryfuel
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			if jerrycurr >= jerryfuel then
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
@@ -327,7 +329,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 

--- a/vrp_legacyfuel/client/main.lua
+++ b/vrp_legacyfuel/client/main.lua
@@ -97,7 +97,7 @@ Citizen.CreateThread(function()
 					local position = GetEntityCoords(vehicle)
 
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to cancel the fueling of your vehicle. $~r~" .. price .. " ~w~+  tax")
-					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "%")
+					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "L")
 					
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -162,7 +162,7 @@ Citizen.CreateThread(function()
 				local jerrycan = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 				
 				if IsFuelingWithJerryCan then
-					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "% - Jerry Can: " .. jerrycan)
+					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "L - Jerry Can: " .. jerrycan)
 
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -227,6 +227,7 @@ Citizen.CreateThread(function()
 			local integer  = math.random(6, 10)
 			local fuelthis = integer / 10
 			local newfuel  = fuel + fuelthis
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			price = price + fuelthis * 0.5 * 1.1
 
@@ -234,7 +235,7 @@ Citizen.CreateThread(function()
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 				Citizen.Wait(150)
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -248,7 +249,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
@@ -307,13 +308,14 @@ Citizen.CreateThread(function()
 			local jerryfuel = fuelthis * 100
 			local jerrycurr = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 			local jerrynew  = jerrycurr - jerryfuel
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			if jerrycurr >= jerryfuel then
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 				Citizen.Wait(150)
 				SetPedAmmo(GetPlayerPed(-1), 883325847, round(jerrynew, 0))
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -327,7 +329,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 


### PR DESCRIPTION
Fix for fuel hud not using correct fuel. If user use sexy speedometer. The fuel gauge will be perfectly sync.
I took the code `Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())` in sexyspeedometer. I also did change the % to L because now it will use the handling petrol tank.  Most cars have 65L  and some other have much more and less.  So it's better to see L than % cause it would stop a 65% if the tank has 65L max on handling.
