### PR TITLE
Same update as the esx_legacy

### DIFF
--- a/LegacyFuel/client/main.lua
+++ b/LegacyFuel/client/main.lua
@@ -95,7 +95,7 @@ Citizen.CreateThread(function()
 					local position = GetEntityCoords(vehicle)
 
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to cancel the fueling of your vehicle.")
-					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "%")
+					DrawText3Ds(position.x, position.y, position.z + 0.5, fuel .. "L")
 					
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -128,7 +128,7 @@ Citizen.CreateThread(function()
 
 						IsFueling = false
 					end
-				elseif fuel > 95.0 then
+				elseif fuel >= Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat()) then
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Vehicle is too filled with gas to be fueled")
 				else
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to fuel your vehicle.")
@@ -156,7 +156,7 @@ Citizen.CreateThread(function()
 				local jerrycan = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 				
 				if IsFuelingWithJerryCan then
-					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "% - Jerry Can: " .. jerrycan)
+					DrawText3Ds(coords.x, coords.y, coords.z + 0.5, "Press ~g~G ~w~to cancel fueling the vehicle. Currently at: " .. fuel .. "L - Jerry Can: " .. jerrycan)
 
 					DisableControlAction(0, 0, true) -- Changing view (V)
 					DisableControlAction(0, 22, true) -- Jumping (SPACE)
@@ -221,11 +221,12 @@ Citizen.CreateThread(function()
 			local integer  = math.random(6, 10)
 			local fuelthis = integer / 10
 			local newfuel  = fuel + fuelthis
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 			Citizen.Wait(150)
 
-			if newfuel < 100 then
+			if newfuel < (maxfuel) then
 				SetVehicleFuelLevel(vehicle, newfuel)
 
 				for i = 1, #Vehicles do
@@ -239,7 +240,7 @@ Citizen.CreateThread(function()
 					end
 				end
 			else
-				SetVehicleFuelLevel(vehicle, 100.0)
+				SetVehicleFuelLevel(vehicle, maxfuel)
 				loadAnimDict("reaction@male_stand@small_intro@forward")
 				TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
@@ -271,13 +272,14 @@ Citizen.CreateThread(function()
 			local jerryfuel = fuelthis * 100
 			local jerrycurr = GetAmmoInPedWeapon(GetPlayerPed(-1), 883325847)
 			local jerrynew  = jerrycurr - jerryfuel
+			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
 			if jerrycurr >= jerryfuel then
 				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
 				Citizen.Wait(150)
 				SetPedAmmo(GetPlayerPed(-1), 883325847, round(jerrynew, 0))
 
-				if newfuel < 100 then
+				if newfuel < (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -291,7 +293,7 @@ Citizen.CreateThread(function()
 						end
 					end
 				else
-					SetVehicleFuelLevel(vehicle, 100.0)
+					SetVehicleFuelLevel(vehicle, maxfuel)
 					loadAnimDict("reaction@male_stand@small_intro@forward")
 					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
@@ -407,7 +409,7 @@ Citizen.CreateThread(function()
 			end
 
 			if not found then
-				integer = math.random(200, 800)
+				integer = math.random(200, 300)
 				fuel 	= integer / 10
 
 				table.insert(Vehicles, {plate = plate, fuel = fuel})
@@ -483,7 +485,7 @@ function DisplayHud()
 		end
 
 		x = 0.01135
-		y = 0.002
+		y = 0.032
 
 		DrawAdvancedText(0.2195 - x, 0.77 - y, 0.005, 0.0028, 0.6, fuel, 255, 255, 255, 255, 6, 1)
 
@@ -491,6 +493,7 @@ function DisplayHud()
 		DrawAdvancedText(0.174 - x, 0.77 - y, 0.005, 0.0028, 0.6, kmh, 255, 255, 255, 255, 6, 1)
 
 		DrawAdvancedText(0.148 - x, 0.7765 - y, 0.005, 0.0028, 0.4, "mp/h              km/h              Fuel", 255, 255, 255, 255, 6, 1)
+		DrawAdvancedText(0.148 - x, 0.77 - y, 0.005, 0.0028, 0.6, "                            L", 255, 255, 255, 255, 6, 1)
 	end
 end
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# LegacyFuel
+
+It is almost the original version with few edit.
+<br>
+What’s been edited:
+<br>
+*Hud now display L next to fuel number Example 28L
+<br>
+*While fueling will display L example 28L until full
+<br>
+*Will use maxfuel from petrol tank which is handling file.
+  <br>
+*Most vehicle has 65 but few have more or less.
+<br>
+*Will show vehicle is too filled base on the vehicle petrol tank.
+<br>
+<br>
+Video
+<br>
+https://youtu.be/YxBcelRlxXQ

--- a/esx_legacyfuel/client/main.lua
+++ b/esx_legacyfuel/client/main.lua
@@ -132,7 +132,7 @@ Citizen.CreateThread(function()
 						price = 0
 						IsFueling = false
 					end
-				elseif fuel > Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat()) then
+				elseif fuel >= Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat()) then
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Vehicle is too filled with gas to be fueled")
 				elseif cash <= 0 then
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "You currently don't have enough money on you to buy fuel with")
@@ -445,7 +445,7 @@ Citizen.CreateThread(function()
 			end
 
 			if not found then
-				integer = math.random(200, 800)
+				integer = math.random(200, 600)
 				fuel 	= integer / 10
 
 				table.insert(Vehicles, {plate = plate, fuel = fuel})

--- a/esx_legacyfuel/client/main.lua
+++ b/esx_legacyfuel/client/main.lua
@@ -25,6 +25,8 @@ local IsFueling 			  = false
 local IsFuelingWithJerryCan   = false
 local InBlacklistedVehicle	  = false
 local NearVehicleWithJerryCan = false
+local price 				  = 0
+local cash 					  = 0
 
 function DrawText3Ds(x,y,z, text)
     local onScreen,_x,_y=World3dToScreen2d(x,y,z)
@@ -85,7 +87,7 @@ Citizen.CreateThread(function()
 				DisplayHud()
 			end
 
-			if nearPump and IsCloseToLastVehicle  then
+			if nearPump and IsCloseToLastVehicle then
 				local vehicle  = GetPlayersLastVehicle()
 				local fuel 	   = round(GetVehicleFuelLevel(vehicle), 1)
 				
@@ -121,17 +123,21 @@ Citizen.CreateThread(function()
 						loadAnimDict("reaction@male_stand@small_intro@forward")
 						TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
+						TriggerServerEvent('LegacyFuel:PayFuel', price)
 						Citizen.Wait(2500)
 						ClearPedTasksImmediately(GetPlayerPed(-1))
 						FreezeEntityPosition(GetPlayerPed(-1), false)
 						FreezeEntityPosition(vehicle, false)
 
+						price = 0
 						IsFueling = false
 					end
 				elseif fuel > Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat()) then
 					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Vehicle is too filled with gas to be fueled")
+				elseif cash <= 0 then
+					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "You currently don't have enough money on you to buy fuel with")
 				else
-					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to fuel your vehicle.")
+					DrawText3Ds(pumpLoc['x'], pumpLoc['y'], pumpLoc['z'], "Press ~g~G ~w~to fuel your vehicle. $~r~0.5/~w~gallon + tax")
 					
 					if IsControlJustReleased(0, 47) then
 						local vehicle = GetPlayersLastVehicle()
@@ -223,32 +229,62 @@ Citizen.CreateThread(function()
 			local newfuel  = fuel + fuelthis
 			local maxfuel  = Citizen.InvokeNative(0x642FC12F, vehicle, "CHandlingData", "fPetrolTankVolume", Citizen.ReturnResultAnyway(), Citizen.ResultAsFloat())
 
-			TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
-			Citizen.Wait(150)
+			price = price + fuelthis * 0.5 * 1.1
 
-			if newfuel < (maxfuel) then
-				SetVehicleFuelLevel(vehicle, newfuel)
+			if cash >= price then
+				TriggerServerEvent('LegacyFuel:CheckServerFuelTable', plate)
+				Citizen.Wait(150)
 
-				for i = 1, #Vehicles do
-					if Vehicles[i].plate == plate then
-						TriggerServerEvent('LegacyFuel:UpdateServerFuelTable', plate, round(GetVehicleFuelLevel(vehicle), 1))
+				if newfuel <= (maxfuel) then
+					SetVehicleFuelLevel(vehicle, newfuel)
 
-						table.remove(Vehicles, i)
-						table.insert(Vehicles, {plate = plate, fuel = newfuel})
+					for i = 1, #Vehicles do
+						if Vehicles[i].plate == plate then
+							TriggerServerEvent('LegacyFuel:UpdateServerFuelTable', plate, round(GetVehicleFuelLevel(vehicle), 1))
 
-						break
+							table.remove(Vehicles, i)
+							table.insert(Vehicles, {plate = plate, fuel = newfuel})
+
+							break
+						end
+					end
+				else
+					SetVehicleFuelLevel(vehicle, maxfuel)
+					loadAnimDict("reaction@male_stand@small_intro@forward")
+					TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
+
+					TriggerServerEvent('LegacyFuel:PayFuel', price)
+					Citizen.Wait(2500)
+					ClearPedTasksImmediately(GetPlayerPed(-1))
+					FreezeEntityPosition(GetPlayerPed(-1), false)
+					FreezeEntityPosition(vehicle, false)
+
+					price = 0
+					IsFueling = false
+
+					for i = 1, #Vehicles do
+						if Vehicles[i].plate == plate then
+							TriggerServerEvent('LegacyFuel:UpdateServerFuelTable', plate, round(GetVehicleFuelLevel(vehicle), 1))
+
+							table.remove(Vehicles, i)
+							table.insert(Vehicles, {plate = plate, fuel = newfuel})
+
+							break
+						end
 					end
 				end
 			else
-				SetVehicleFuelLevel(vehicle, maxfuel)
+				SetVehicleFuelLevel(vehicle, newfuel)
 				loadAnimDict("reaction@male_stand@small_intro@forward")
 				TaskPlayAnim(GetPlayerPed(-1), "reaction@male_stand@small_intro@forward", "react_forward_small_intro_a", 1.0, 2, -1, 49, 0, 0, 0, 0)
 
+				TriggerServerEvent('LegacyFuel:PayFuel', price)
 				Citizen.Wait(2500)
 				ClearPedTasksImmediately(GetPlayerPed(-1))
 				FreezeEntityPosition(GetPlayerPed(-1), false)
 				FreezeEntityPosition(vehicle, false)
 
+				price = 0
 				IsFueling = false
 
 				for i = 1, #Vehicles do
@@ -279,7 +315,7 @@ Citizen.CreateThread(function()
 				Citizen.Wait(150)
 				SetPedAmmo(GetPlayerPed(-1), 883325847, round(jerrynew, 0))
 
-				if newfuel < (maxfuel) then
+				if newfuel <= (maxfuel) then
 					SetVehicleFuelLevel(vehicle, newfuel)
 
 					for i = 1, #Vehicles do
@@ -435,6 +471,10 @@ Citizen.CreateThread(function()
 			InBlacklistedVehicle = false
 		end
 
+		if nearPump then
+			TriggerServerEvent('LegacyFuel:CheckCashOnHand')
+		end
+
 		local CurrentWeapon = GetSelectedPedWeapon(GetPlayerPed(-1))
 						
 		if CurrentWeapon == 883325847 then
@@ -485,7 +525,7 @@ function DisplayHud()
 		end
 
 		x = 0.01135
-		y = 0.002
+		y = 0.032
 
 		DrawAdvancedText(0.2195 - x, 0.77 - y, 0.005, 0.0028, 0.6, fuel, 255, 255, 255, 255, 6, 1)
 
@@ -493,6 +533,7 @@ function DisplayHud()
 		DrawAdvancedText(0.174 - x, 0.77 - y, 0.005, 0.0028, 0.6, kmh, 255, 255, 255, 255, 6, 1)
 
 		DrawAdvancedText(0.148 - x, 0.7765 - y, 0.005, 0.0028, 0.4, "mp/h              km/h              Fuel", 255, 255, 255, 255, 6, 1)
+		DrawAdvancedText(0.148 - x, 0.77 - y, 0.005, 0.0028, 0.6, "                            L", 255, 255, 255, 255, 6, 1)
 	end
 end
 
@@ -579,6 +620,11 @@ Citizen.CreateThread(function()
 			end
 		end
 	end
+end)
+
+RegisterNetEvent('LegacyFuel:RecieveCashOnHand')
+AddEventHandler('LegacyFuel:RecieveCashOnHand', function(cb)
+	cash = cb
 end)
 
 local gas_stations = {

--- a/esx_legacyfuel/server/main.lua
+++ b/esx_legacyfuel/server/main.lua
@@ -9,6 +9,13 @@ AddEventHandler('LegacyFuel:PayFuel', function(price)
 	xPlayer.removeMoney(amount)
 end)
 
+RegisterServerEvent('LegacyFuel:PayJerryCanFuel')
+AddEventHandler('LegacyFuel:PayJerryCanFuel', function(price)
+	local xPlayer = ESX.GetPlayerFromId(source)
+
+	xPlayer.removeMoney(100)
+end)
+
 local Vehicles = {
 	{ plate = '87OJP476', fuel = 50}
 }


### PR DESCRIPTION
https://forum.fivem.net/t/release-esx-non-esx-legacyfuel-system/148442/283?u=xxfri3ndlyxx
Video
https://youtu.be/YxBcelRlxXQ
 

This version is almost the original version with few edit.

What's been edited:
* Hud now display L next to fuel number Example 28L
* While fueling will display L example 28L until full
* Will use maxfuel from petrol tank which is handling file.
* Most vehicle has 65 but few have more or less.
* Will  show vehicle is too filled base on the vehicle petrol tank.
* Vehicle will now spawn with vehicle between 20L and 60 L

