### PR TITLE
Fix ESX config reference

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -30,7 +30,7 @@ Config.Strings = {
 	CancelFuelingJerryCan = "Press ~g~E ~w~to cancel the fueling"
 }
 
-if not UseESX then
+if not Config.UseESX then
 	Config.Strings.PurchaseJerryCan = "Press ~g~E ~w~to grab a jerry can"
 	Config.Strings.NotEnoughCash = "Nout enough cash"
 end


### PR DESCRIPTION
Very simple reference fix for the 'UseESX' variable within the config