### PR TITLE
Fix the way to get money from account system of ESX Base

### DIFF
--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -84,7 +84,13 @@ Citizen.CreateThread(function()
 			isNearPump = pumpObject
 
 			if Config.UseESX then
-				currentCash = ESX.GetPlayerData().money
+				local playerData = ESX.GetPlayerData()
+				for i=1, #playerData.accounts, 1 do
+					if playerData.accounts[i].name == 'money' then
+						currentCash = playerData.accounts[i].money
+						break
+					end
+				end
 			end
 		else
 			isNearPump = false


### PR DESCRIPTION
As the newer version of the [es_extended](https://github.com/ESX-Org/es_extended) resource has changed how it store player's money to be the accounts system instead, I then changed how to get player's cash from that. This was the result from ditching the old `essentialmode`.